### PR TITLE
remove masonry.js

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -17,11 +17,6 @@ $(document).on('turbolinks:load', preloader);
     }
   });
 
-  // masonry
-  $('.masonry-wrapper').masonry({
-    columnWidth: 1,
-  });
-
   // Get Parameters from some url
   var getUrlParameter = function getUrlParameter(sPageURL) {
     var url = sPageURL.split('?');

--- a/config.toml
+++ b/config.toml
@@ -75,10 +75,10 @@ link = "plugins/bootstrap/bootstrap.min.js"
 attributes = ""
 page = "/"
 
-[[params.plugins.js]]
-link = "plugins/masonry/masonry.min.js"
-attributes = ""
-page = "/"
+# [[params.plugins.js]]
+#link = "plugins/masonry/masonry.min.js"
+#attributes = ""
+#page = "/"
 
 [[params.plugins.js]]
 link = "plugins/featherlight/featherlight.min.js"

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -194,19 +194,6 @@
   </div>
 </section>
 
-<!-- faq -->
-<!-- {{ with .Site.GetPage "/faq" }}
-<section class="section pb-0">
-  <div class="container">
-    <h2 class="section-title">{{ .Title }}</h2>
-    <div class="row masonry-wrapper">
-      {{ .Content }}
-    </div>
-  </div>
-</section>
-{{ end }} -->
-<!-- /faq -->
-
 <section class="section events-section">
   <div class="container">
     <div class="event-header row justify-content-center align-items-sm-baseline justify-content-sm-between">


### PR DESCRIPTION
This PR removew masonry.js as it's unused and we can use some more reduction in number of loaded script.

Signed-off-by: Adityo Pratomo <adityo@tetrate.io>
