### PR TITLE
update past event

### DIFF
--- a/content/en/community/event/getistio-inaugural.md
+++ b/content/en/community/event/getistio-inaugural.md
@@ -4,16 +4,16 @@ date: 2021-01-29T11:00:00+07:00
 description: "Episode 00: What is GetIstio - Inaugural Community Meetup"
 categories: "event"
 image: "images/events/getistio-inaugural-meetup.webp"
-eventLink: "https://us02web.zoom.us/j/89163866904"
+eventLink: "https://www.youtube.com/watch?v=XSgpTruF-gY"
 eventDate: "2021-02-18T09:00:00"
-pastEvent: false
+pastEvent: true
 weight: 1
 timezone: PST
 ---
 
 {{< eventDate >}}
 
-- Zoom: <https://us02web.zoom.us/j/89163866904>
+- Recording: <https://www.youtube.com/watch?v=XSgpTruF-gY>
 - Meeting note: [Google doc](https://docs.google.com/document/d/1jgcnuefeFlFEVtfeSVmTOxuUvI7KPznFN5zR9hzrjew/edit?usp=sharing)
 
 The inaugural meetup will be a special edition with 90 minutes to introduce the community, unpack the GetIstio and GetEnvoy projects, and hear what's new in the Istio 1.9 release. We look forward to diving into the topics, demonstrating some new Istio capabilities and answering all of your questions during the Q&A session.
@@ -31,5 +31,3 @@ The inaugural meetup will be a special edition with 90 minutes to introduce the 
     - Demonstration of new features related to VMs, observability, and more
 - Q&A
 - Closing with community resource links
-
-{{< eventLink "Join here">}}

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -43,6 +43,9 @@
 - id: go_to_event
   translation: Go to Event
 
+- id: watch_recording
+  translation: Watch Recording
+
 - id: get_in_touch
   translation: Get in Touch
 

--- a/layouts/_default/community-events.html
+++ b/layouts/_default/community-events.html
@@ -55,6 +55,36 @@
       {{ end }}
     </div>
   </div>
+  <div class="container">
+    <h3 class="text-center my-4">Past Events</h3>
+    <div class="row">
+      {{ range .Site.Taxonomies.categories.event }}
+      {{ if eq .Page.Params.pastEvent true }}
+      <div class="col-lg-6 mb-4 p-4">
+        <div class="card match-height event-card">
+          <p class="event-date pb-2">
+            {{ if .Page.Params.eventEndDate }}
+            {{ dateFormat (i18n "date_format") .Page.Params.eventDate }} - {{ dateFormat (i18n "date_format") .Page.Params.eventEndDate }}
+            {{ else }}
+            {{ dateFormat (i18n "date_format") .Page.Params.eventDate }} {{ dateFormat (i18n "minute") .Page.Params.eventDate }} {{ .Page.Params.timezone }}
+            {{ end }}
+            <span><i class="ti-calendar"></i></span>
+          </p>
+          <a href="{{ .Page.RelPermalink }}">
+            <h5>{{ .Page.Title }}</h5>
+          </a>
+          <img src="{{ .Page.Params.image |relURL }}" />
+          <p>{{ .Page.Description }}</p>
+          <div class="event-actions row">
+            <a class="btn btn-sm" href="{{ .Page.RelPermalink }}">{{ i18n "learn_more" }}</a>
+            <a class="btn btn-sm btn-primary" href="{{ .Page.Params.eventLink }}" target="_blank">{{ i18n "watch_recording" }}</a>
+          </div>
+        </div>
+      </div>
+      {{ end }}
+      {{ end }}
+    </div>
+  </div>
 </section>
 
 <section class="community-contribution">


### PR DESCRIPTION
This PR adds the following:

- Past event section in Community landing page
- Updates GetIstio Inaugural event to past event, so it doesn't appear in the homepage
- Also updates the link to the past event so it goes to the YouTube recording.

Signed-off-by: Adityo Pratomo <adityo@tetrate.io>