### PR TITLE
chore: fix sidebar navigation errors

### DIFF
--- a/content/en/ecosystem-partners/_index.md
+++ b/content/en/ecosystem-partners/_index.md
@@ -1,0 +1,21 @@
+---
+title: "Ecosystem & Partners"
+date: 2018-12-29T11:02:05+06:00
+icon: "ti-comments"
+description: "Take a look at GetIstio partners and see how they benefit from it."
+# type dont remove or customize
+type : "docs"
+weight: 6
+# set these 2 to make it featured in homepage
+featured: true
+featureOrder: 4
+---
+
+We establish partnerships with various organizations to create synergy between Istio and their products, in order to give great value to the community. Here, we can learn more about these partnerships that you will find beneficial.
+
+<ul>
+  <li><a href="appviewx">AppViewX</a></li>
+  <li><a href="jetstack">Jetstack</a></li>
+  <li><a href="keyfactor">Keyfactor</a></li>
+  <li><a href="weaveworks">Weaveworks</a></li>
+<ul>

--- a/content/zh/community/contributing/_index.md
+++ b/content/zh/community/contributing/_index.md
@@ -4,8 +4,6 @@ url: /zh/community/contributing
 weight: 3
 ---
 
-# 对 GetIstio 贡献
-
 我们欢迎社区的贡献。请仔细阅读以下指南，以最大限度地提高您的 PR 被合并的机会。
 
 ## 代码审查


### PR DESCRIPTION
- put back the deleted ecyocystem partners page
- delete the duplicated words