### PR TITLE
Redirect latest version of download.sh from getmesh repo

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -9,3 +9,10 @@ from = "https://www.getistio.io"
 to = "https://istio.tetratelabs.io"
 status = 301
 force = true
+
+# Redirect latest version of download.sh from getmesh repo
+[[redirects]]
+from = "/install-getmesh.sh"
+to = "https://raw.githubusercontent.com/tetratelabs/getmesh/main/download.sh"
+force = true
+status = 302


### PR DESCRIPTION
This uses more intuitive name we use in getenvoy, but suffix of getmesh since
this will end up as https://istio.tetratelabs.io/install-getmesh.sh

This cuts out a CI step and build indirection same as we did in getenvoy