### PR TITLE
Sets up redirect for getmesh manifest.json

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -20,6 +20,6 @@ status = 302
 # Redirect latest version of manifest.json from getmesh repo
 [[redirects]]
 from = "/getmesh/manifest.json"
-to = "https://raw.githubusercontent.com/tetratelabs/getmesh/main/manifest.json"
+to = "https://raw.githubusercontent.com/tetratelabs/getmesh/main/site/manifest.json"
 force = true
 status = 302

--- a/netlify.toml
+++ b/netlify.toml
@@ -12,7 +12,14 @@ force = true
 
 # Redirect latest version of download.sh from getmesh repo
 [[redirects]]
-from = "/install-getmesh.sh"
+from = "/getmesh/install.sh"
 to = "https://raw.githubusercontent.com/tetratelabs/getmesh/main/download.sh"
+force = true
+status = 302
+
+# Redirect latest version of manifest.json from getmesh repo
+[[redirects]]
+from = "/getmesh/manifest.json"
+to = "https://raw.githubusercontent.com/tetratelabs/getmesh/main/manifest.json"
 force = true
 status = 302

--- a/netlify.toml
+++ b/netlify.toml
@@ -13,7 +13,7 @@ force = true
 # Redirect latest version of download.sh from getmesh repo
 [[redirects]]
 from = "/getmesh/install.sh"
-to = "https://raw.githubusercontent.com/tetratelabs/getmesh/main/download.sh"
+to = "https://raw.githubusercontent.com/tetratelabs/getmesh/main/site/install.sh"
 force = true
 status = 302
 


### PR DESCRIPTION
Like last, this cuts out a build step and second domain for hosting text files.

This switches to http path instead of path encoding

https://istio.tetratelabs.io/getmesh/install.sh
https://istio.tetratelabs.io/getmesh/manifest.json

See https://github.com/tetratelabs/getmesh/pull/47
