### PR TITLE
update event content

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ To add Event, go to the `/content/community/event` directory and add a Markdown 
 
 ```yaml
 title: "Sample Event 1"
-date: 2018-12-29T11:02:05+06:00
 description: "This is description for Sample Event 1"
 categories: "event"
 image: "images/webinar_dummy.jpg"

--- a/content/en/community/event/tid-episode-012/index.md
+++ b/content/en/community/event/tid-episode-012/index.md
@@ -1,6 +1,5 @@
 ---
 title: 'Episode 09: Customizing Istio metrics'
-date: 2021-08-24T11:00:00+07:33
 description: 'Join us on August 19th for another Istio weekly episode where we will talk about how to customize and create new service-level metrics.'
 categories: 'event'
 image: 'images/events/episode-012-thumbnail.jpg'

--- a/content/en/community/event/tid-episode-013/index.md
+++ b/content/en/community/event/tid-episode-013/index.md
@@ -1,13 +1,11 @@
 ---
 title: 'Episode 10: How to become a certified Istio expert?'
-date: 2021-08-24T11:00:00+07:27
 description: 'Join us to learn about the Tetrate Istio Certified Administrator exam. Vijay Nadkarni will share his tips and tricks on how he prepared and passed the TCIA exam.'
-categories: 'event'
+categories: "event"
 image: 'images/events/episode-013-thumbnail.jpg'
 eventLink: 'https://www.youtube.com/watch?v=29JQA5jQ8OI'
 eventDate: 2021-09-02T11:00:00
 pastEvent: false
-weight: 16
 timezone: PST
 ---
 

--- a/layouts/_default/community-events.html
+++ b/layouts/_default/community-events.html
@@ -26,7 +26,7 @@
 {{ end }}
 <section class="community-events">
   <div class="container">
-      <h3 class="text-center my-4">{{ i18n "upcoming_getistio_community_events" }}</h3>
+    <h3 class="text-center my-4">{{ i18n "upcoming_getistio_community_events" }}</h3>
     <div class="row">
       {{ range .Site.Taxonomies.categories.event }}
       {{ if eq .Page.Params.pastEvent false }}


### PR DESCRIPTION
fix missing event content. Some events are not displayed. I found that the fix is to remove the `date` frontmatter in the event markdown file. Pls refer to the new README and the events in this PR

cc: @MB-Designs @rootsongjc 