### PR TITLE
removing FIPS from the download page

### DIFF
--- a/layouts/shortcodes/downloads.html
+++ b/layouts/shortcodes/downloads.html
@@ -1,110 +1,110 @@
-  {{ $os_type := .Get 0 }}  
-  
-  {{ $url_beginning_distro := "https://dl.getistio.io/public/raw/files/istio-" }}
-  {{ $url_beginning_cli := "https://dl.getistio.io/public/raw/files/istioctl-" }}
-  
-  
-  {{ $platforms := slice }}
-  {{ $file_name_prefix := "" }}
-  {{ $file_name_suffix := ".tar.gz" }}
-  {{ $multiple_version := false}}
-  
-  {{ if eq "linux" $os_type }}
-    {{ $platforms = (slice "amd64" "arm64" "armv7") }}
-    {{ $file_name_prefix = "-linux-" }}
-  {{ else if eq "osx" $os_type }}
-    {{ $platforms = (slice "-osx") }}
-  {{ else if eq "windows" $os_type }}
-    {{ $platforms = (slice "-win") }}
-    {{ $file_name_suffix = ".zip" }}
-  {{ else }}
-    {{ $os_type = "unspecified" }}
+{{ $os_type := .Get 0 }}
+
+{{ $url_beginning_distro := "https://dl.getistio.io/public/raw/files/istio-" }}
+{{ $url_beginning_cli := "https://dl.getistio.io/public/raw/files/istioctl-" }}
+
+
+{{ $platforms := slice }}
+{{ $file_name_prefix := "" }}
+{{ $file_name_suffix := ".tar.gz" }}
+{{ $multiple_version := false}}
+
+{{ if eq "linux" $os_type }}
+{{ $platforms = (slice "amd64" "arm64" "armv7") }}
+{{ $file_name_prefix = "-linux-" }}
+{{ else if eq "osx" $os_type }}
+{{ $platforms = (slice "-osx") }}
+{{ else if eq "windows" $os_type }}
+{{ $platforms = (slice "-win") }}
+{{ $file_name_suffix = ".zip" }}
+{{ else }}
+{{ $os_type = "unspecified" }}
+{{ end }}
+
+
+{{ range $platform_name := $platforms }}
+{{ $.Scratch.Add "url_ending" $file_name_prefix }}
+{{ $.Scratch.Add "url_ending" $platform_name }}
+{{ $.Scratch.Add "url_ending" $file_name_suffix }}
+{{ $.Scratch.SetInMap "file_suffix" $platform_name ($.Scratch.Get "url_ending") }}
+{{ $.Scratch.Delete "url_ending" }}
+{{ end }}
+
+
+{{ $manifest := getJSON "https://istio.tetratelabs.io/getmesh/manifest.json" }}
+
+{{ range $manifest.istio_distributions }}
+{{ $.Scratch.Add "version_list" (slice .version) }}
+{{ end }}
+{{ range $version_value := $.Scratch.Get "version_list" }}
+{{ $.Scratch.Add "version_trimmed" (slice (strings.TrimRight "." (slicestr $version_value 0 4))) }} {{ end}}
+{{ range $version_supported := uniq (.Scratch.Get "version_trimmed") }}
+{{ $previous_value := 0 }}
+{{ range $version_value := $.Scratch.Get "version_list" }}
+{{ if findRE $version_supported $version_value }}
+{{ $subversion := (int (strings.TrimLeft "." (substr $version_value -2))) }}
+{{ if le $previous_value $subversion }}
+{{ $previous_value = $subversion }}
+{{ $.Scratch.Set "highest_minor_supported_version" $version_value }}
+{{ end }}
+{{ end }}
+{{ end }}
+{{ $.Scratch.Add "latest_versions" (slice ($.Scratch.Get "highest_minor_supported_version")) }}
+{{ end }}
+
+<table>
+  <th>Distribution type</th>
+  <th>Istio version</th>
+  <th>Release Notes</th>
+  <th>Full Istio download URL</th>
+  <th>Istioctl download URL</th>
+
+
+  {{ range $valid_version := $.Scratch.Get "latest_versions" }}
+  {{ range $manifest.istio_distributions }}
+  {{ if and (findRE $valid_version .version) (ne $os_type "unspecified") (ne .flavor "tetratefips")}}
+  {{ $release_url := index (.release_notes) 0}}
+  <tr>
+    <td> {{ .flavor }}-v{{ .flavor_version }} </td>
+    <td> {{ .version }} </td>
+
+    {{ if gt (len ($.Scratch.Get "file_suffix")) 1 }} {{ $multiple_version = true }} {{ end }}
+
+    <td> <a href={{ $release_url }}>Release Notes {{ .version }}</a> </td>
+    <td>
+
+      {{ if $multiple_version }} <strong>Istio Distro</strong><br> {{ end }}
+
+      {{ $.Scratch.Add "istio_url_middle" .version }}
+      {{ $.Scratch.Add "istio_url_middle" "-" }}
+      {{ $.Scratch.Add "istio_url_middle" .flavor }}
+      {{ $.Scratch.Add "istio_url_middle" "-v" }}
+      {{ $.Scratch.Add "istio_url_middle" (string .flavor_version) }}
+
+      {{ range $type,$url_ending := $.Scratch.Get "file_suffix" }}
+      {{ if not $multiple_version }} {{ $type = "Istio Distro" }} {{ end }}
+
+      <a href={{ $url_beginning_distro }}{{ $.Scratch.Get "istio_url_middle" }}{{ $url_ending }}>{{ $type }}</a> <br>
+      {{ end }}
+
+    </td>
+
+    <td>
+      {{ if $multiple_version }} <strong>istioctl</strong><br> {{ end }}
+
+      {{ range $type,$url_ending := $.Scratch.Get "file_suffix" }}
+      {{ if not $multiple_version }} {{ $type = "istioctl" }} {{ end }}
+
+      <a href={{ $url_beginning_cli }}{{ $.Scratch.Get "istio_url_middle" }}{{ $url_ending }}>{{ $type }}</a> <br>
+      {{ end }}
+
+    </td>
+
+    {{ $.Scratch.Delete "istio_url_middle" }}
+
+  </tr>
+
   {{ end }}
-
-
-  {{ range $platform_name := $platforms }}
-    {{ $.Scratch.Add "url_ending" $file_name_prefix }}
-    {{ $.Scratch.Add "url_ending" $platform_name }}
-    {{ $.Scratch.Add "url_ending" $file_name_suffix }}
-    {{ $.Scratch.SetInMap "file_suffix"  $platform_name ($.Scratch.Get "url_ending") }}
-    {{ $.Scratch.Delete "url_ending" }}
   {{ end }}
-
-
-  {{ $manifest := getJSON "https://istio.tetratelabs.io/getmesh/manifest.json" }}
-
-  {{ range $manifest.istio_distributions }} 
-    {{ $.Scratch.Add "version_list" (slice .version) }} 
   {{ end }}
-  {{ range $version_value := $.Scratch.Get "version_list" }} 
-    {{ $.Scratch.Add "version_trimmed" (slice (strings.TrimRight "." (slicestr $version_value 0 4))) }} {{ end}}
-    {{ range $version_supported := uniq (.Scratch.Get "version_trimmed") }}
-      {{ $previous_value := 0 }}
-        {{ range $version_value := $.Scratch.Get "version_list" }} 
-          {{ if findRE $version_supported $version_value }}
-            {{ $subversion := (int (strings.TrimLeft "." (substr $version_value -2))) }}
-              {{ if le $previous_value $subversion }}
-                 {{ $previous_value = $subversion }} 
-                 {{ $.Scratch.Set "highest_minor_supported_version" $version_value }} 
-              {{ end }}
-          {{ end }}
-        {{ end }}
-    {{ $.Scratch.Add "latest_versions" (slice ($.Scratch.Get "highest_minor_supported_version")) }}
-  {{ end }}
-
-   <table>
-      <th>Distribution type</th>
-      <th>Istio version</th>
-      <th>Release Notes</th>
-      <th>Full Istio download URL</th>
-      <th>Istioctl download URL</th>
-
-   
-   {{ range $valid_version := $.Scratch.Get "latest_versions" }}
-     {{ range $manifest.istio_distributions }}
-       {{ if and (findRE $valid_version .version) (ne $os_type "unspecified") }}
-         {{ $release_url := index (.release_notes) 0}}
-         <tr>
-         <td> {{ .flavor }}-v{{ .flavor_version }} </td>
-         <td> {{ .version }} </td>
-
-         {{ if gt (len ($.Scratch.Get "file_suffix")) 1 }} {{ $multiple_version = true }} {{ end }}
-
-         <td> <a href={{ $release_url }}>Release Notes {{ .version }}</a> </td> 
-	 <td>
-
-         {{ if $multiple_version }} <strong>Istio Distro</strong><br>  {{ end }}
-
-       	 {{ $.Scratch.Add "istio_url_middle" .version }}
-       	 {{ $.Scratch.Add "istio_url_middle" "-" }}
-       	 {{ $.Scratch.Add "istio_url_middle" .flavor }}
-       	 {{ $.Scratch.Add "istio_url_middle" "-v" }} 
-         {{ $.Scratch.Add "istio_url_middle" (string .flavor_version)  }}
-         
-         {{ range $type,$url_ending := $.Scratch.Get "file_suffix" }}
-           {{ if not $multiple_version }} {{ $type = "Istio Distro" }} {{ end }}
-
-           <a href={{ $url_beginning_distro }}{{ $.Scratch.Get "istio_url_middle" }}{{ $url_ending }}>{{ $type }}</a> <br>
-         {{ end }}
-
-         </td>
-
-	 <td>
-         {{ if $multiple_version }} <strong>istioctl</strong><br> {{ end }}
-
-         {{ range $type,$url_ending := $.Scratch.Get "file_suffix" }}
-           {{ if not $multiple_version }} {{ $type = "istioctl" }} {{ end }}
-
-       	   <a href={{ $url_beginning_cli }}{{ $.Scratch.Get "istio_url_middle" }}{{ $url_ending }}>{{ $type }}</a> <br>
-         {{ end }}
-
-         </td>
-
-         {{ $.Scratch.Delete "istio_url_middle" }}
-
-       </tr>
-
-       {{ end }}
-     {{ end }}
-   {{ end }}
-   </table>
+</table>


### PR DESCRIPTION
per https://github.com/tetrateio/protocol/issues/227 removing FIPS links from the download page.