### PR TITLE
Add more references to the Tetrate support channels

### DIFF
--- a/content/en/community/_index.md
+++ b/content/en/community/_index.md
@@ -10,7 +10,7 @@ weight: 90
 
 There are multiple ways you can contribute and get involved in the community:
 
-- Join the **#GetMesh** channel on [Tetrate Community Slack](https://tetr8.io/tetrate-community).
+- Join the **#tid-and-getmesh** channel on [Tetrate Community Slack](https://tetr8.io/tetrate-community).
 - Start [contributing](/community/contributing/) to the Tetrate Istio Distro project on [Github](https://github.com/tetratelabs/getmesh).
 - Join and participate at one of our [events](https://tetrate.io/events).
 - Watch [Tetrate Tech Talks](https://tetr8.io/techtalks) videos.

--- a/content/en/community/_index.md
+++ b/content/en/community/_index.md
@@ -10,8 +10,8 @@ weight: 90
 
 There are multiple ways you can contribute and get involved in the community:
 
+- Join the **#GetMesh** channel on [Tetrate Community Slack](https://tetr8.io/tetrate-community).
 - Start [contributing](/community/contributing/) to the Tetrate Istio Distro project on [Github](https://github.com/tetratelabs/getmesh).
 - Join and participate at one of our [events](https://tetrate.io/events).
 - Watch [Tetrate Tech Talks](https://tetr8.io/techtalks) videos.
-- Join the **#GetMesh** channel on [Tetrate Community Slack](https://tetr8.io/tetrate-community).
 - Get Istio certified at [Tetrate Academy](https://academy.tetrate.io/courses/certified-istio-administrator).

--- a/content/en/quickstart/_index.md
+++ b/content/en/quickstart/_index.md
@@ -7,7 +7,7 @@ type: 'docs'
 weight: 11
 ---
 
-<h3>Download</h3>
+### Download
 
 The command below obtains a shell script that downloads and installs GetMesh CLI binary that corresponds to the OS distribution detected by the script (currently MacOS and Linux are supported). Additionally the most recent supported version of Istio is downloaded. Also script adds GetMesh location to PATH variable (re-login is required to get PATH populated)
 
@@ -24,7 +24,7 @@ tetratelabs/getmesh info found version: 1.1.1 for v1.1.1/linux/amd64
 tetratelabs/getmesh info installed /home/mathetake/./bin/getmesh
 ```
 
-<h3>Install Istio</h3>
+### Install Istio
 
 As explained earlier - GetMesh by default communicates to the cluster defined by your Kubernetes configuration. Please make sure you’re connected to the correct cluster before proceeding with the installation steps.
 
@@ -46,11 +46,11 @@ This will install the Istio demo profile with ["Istio core" "Istiod" "Ingress ga
 ✔ Installation complete
 ```
 
-<h3>Verify it's Worked!</h3>
+### Verify it Worked!
 
 After the previous step is completed, you can use GetMesh to verify that the installation has succeeeded.
 
-**Check the Install Version**
+**Check the Installed GetMesh and Istio Versions**
 
 Run `getmesh version` to check the versions of GetMesh and the target Istio install:
 
@@ -67,7 +67,7 @@ data plane version: 1.8.2-distro-v0 (2 proxies)
 
 **Check the Istio Configuration**
 
-Run `getmesh config-validate` to confirm that GetMesh can access the Istio configuration. With a fresh install of Kubernetes and Istio, the output will look similar to the below:
+Run `getmesh config-validate` to confirm that GetMesh can access and validate the configuration in the Istio cluster. With a fresh install of Kubernetes and Istio, the output will look similar to the below:
 
 ```sh
 $ getmesh config-validate
@@ -82,8 +82,8 @@ The error codes of the found issues are prefixed by 'IST' or 'KIA'. For the deta
 - https://kiali.io/documentation/latest/validations/ for 'KIA' error codes
 ```
 
-<h3>Next Steps</h3>
+### Next Steps
 
 Read on for next steps with Tetrate Istio Distro and GetMesh.
 
-For community support, join Tetrate's <a href="https://tetr8.io/tetrate-community">#GetMesh Slack Channel</a>.
+For community support, join Tetrate's [#tid-and-getmesh Slack Channel](https://tetr8.io/tetrate-community).

--- a/content/en/quickstart/_index.md
+++ b/content/en/quickstart/_index.md
@@ -46,11 +46,13 @@ This will install the Istio demo profile with ["Istio core" "Istiod" "Ingress ga
 ✔ Installation complete
 ```
 
-After the previous step is completed - the validation can be done by confirming GetMesh and Istio version installed:
+<h3>Verify it's Worked!</h3>
 
-```sh
-getmesh version
-```
+After the previous step is completed, you can use GetMesh to verify that the installation has succeeeded.
+
+**Check the Install Version**
+
+Run `getmesh version` to check the versions of GetMesh and the target Istio install:
 
 Output:
 
@@ -63,13 +65,9 @@ control plane version: 1.8.2-distro-v0
 data plane version: 1.8.2-distro-v0 (2 proxies)
 ```
 
-Additionally to the version output - a user can confirm that config validation is functioning as expected by issuing the following command:
+**Check the Istio Configuration**
 
-```sh
-getmesh config-validate
-```
-
-With fresh install of Kubernetes cluster and Istio - the output will look similar to the below:
+Run `getmesh config-validate` to confirm that GetMesh can access the Istio configuration. With a fresh install of Kubernetes and Istio, the output will look similar to the below:
 
 ```sh
 $ getmesh config-validate
@@ -83,3 +81,9 @@ The error codes of the found issues are prefixed by 'IST' or 'KIA'. For the deta
 - https://istio.io/latest/docs/reference/config/analysis/ for 'IST' error codes
 - https://kiali.io/documentation/latest/validations/ for 'KIA' error codes
 ```
+
+<h3>Next Steps</h3>
+
+Read on for next steps with Tetrate Istio Distro and GetMesh.
+
+For community support, join Tetrate's <a href="https://tetr8.io/tetrate-community">#GetMesh Slack Channel</a>.

--- a/content/en/quickstart/_index.md
+++ b/content/en/quickstart/_index.md
@@ -58,11 +58,11 @@ Output:
 
 ```sh
 $ getmesh version
-GetMesh version: 0.3.0
-Active istioctl: 1.8.2-distro-v0
-client version: 1.8.2-distro-v0
-control plane version: 1.8.2-distro-v0
-data plane version: 1.8.2-distro-v0 (2 proxies)
+getmesh version: 1.1.4
+active istioctl: 1.15.3-tetrate-v0
+client version: 1.15.3-tetrate-v0
+control plane version: 1.15.3-tetrate-v0
+data plane version: 1.15.3-tetrate-v0 (2 proxies)
 ```
 
 **Check the Istio Configuration**

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -40,6 +40,9 @@
 - id: learn_more
   translation: Learn More
 
+- id: get_support
+  translation: Get Support
+
 - id: go_to_event
   translation: Go to Event
 

--- a/i18n/zh.yaml
+++ b/i18n/zh.yaml
@@ -40,6 +40,9 @@
 - id: learn_more
   translation: 了解详情
 
+- id: get_support
+  translation: 得到支持
+
 - id: go_to_event
   translation: 转到活动
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -167,6 +167,8 @@
         {{ end }}
         <div class="pt-4 row justify-content-center">
             <a href="{{ "/getmesh-cli/"| relLangURL }}" class="btn btn-sm learn-more">{{ i18n "learn_more" }}</a>
+            &nbsp;&nbsp;
+            <a href="{{ "https://tetr8.io/tetrate-community"| relLangURL }}" class="btn btn-sm learn-more">{{ i18n "get_support" }}</a>
         </div>
       </div>
     </div>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -20,7 +20,7 @@
           {{ end }}
         </ul>
       </div>
-      <small class="text-white">Support: Join our <a href="https://tetr8.io/tetrate-community" target="_blank">#GetMesh Slack Channel</a> for Community Support</small><br />
+      <small class="text-white">Support: Join our <a href="https://tetr8.io/tetrate-community" target="_blank">#tid-and-getmesh Slack Channel</a> for Community Support</small><br />
       <small class="text-white">License: Tetrate Istio Distro is an open source project and is released under Apache License 2.0 | <a href="https://www.tetrate.io/privacy" target="_blank">Privacy Statement</a></small><br />
       <small class="text-white">Official project site of istio is <a href="https://www.istio.io" target="_blank">istio.io</a></small><br />
       <small class="text-white">Copyright &copy; {{ dateFormat "2006" now }} <a href="https://www.tetrate.io" target="_blank">Tetrate</a> All rights reserved.</small>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -20,6 +20,7 @@
           {{ end }}
         </ul>
       </div>
+      <small class="text-white">Support: Join our <a href="https://tetr8.io/tetrate-community" target="_blank">#GetMesh Slack Channel</a> for Community Support</small><br />
       <small class="text-white">License: Tetrate Istio Distro is an open source project and is released under Apache License 2.0 | <a href="https://www.tetrate.io/privacy" target="_blank">Privacy Statement</a></small><br />
       <small class="text-white">Official project site of istio is <a href="https://www.istio.io" target="_blank">istio.io</a></small><br />
       <small class="text-white">Copyright &copy; {{ dateFormat "2006" now }} <a href="https://www.tetrate.io" target="_blank">Tetrate</a> All rights reserved.</small>


### PR DESCRIPTION
Add more references to Tetrate support channels:

- Homepage
- Site footer
- Quickstart docs
- Promote higher on community resources page