### PR TITLE
Add download redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -33,7 +33,7 @@ force = true
 
 # Redirect download page
 [[redirects]]
-from = "/download/*"
+from = "/download"
 to = "https://docs.tetrate.io/istio-subscription/releases/"
 status = 301
 force = true

--- a/netlify.toml
+++ b/netlify.toml
@@ -26,7 +26,14 @@ status = 302
 
 # Redirect to the cloudsmith binary
 [[redirects]]
- from = "/getmesh/files/*"
- to = "https://dl.getistio.io/public/raw/files/:splat"
- status = 302
- force = true
+from = "/getmesh/files/*"
+to = "https://dl.getistio.io/public/raw/files/:splat"
+status = 302
+force = true
+
+# Redirect download page
+[[redirects]]
+from = "/download/*"
+to = "https://docs.tetrate.io/istio-subscription/releases/"
+status = 301
+force = true

--- a/netlify.toml
+++ b/netlify.toml
@@ -33,7 +33,7 @@ force = true
 
 # Redirect download page
 [[redirects]]
-from = "/download"
+from = "/download/*"
 to = "https://docs.tetrate.io/istio-subscription/releases/"
 status = 301
 force = true


### PR DESCRIPTION
This will redirect all `/download/*` links to https://docs.tetrate.io/istio-subscription/releases/