### PR TITLE
Entire Site Redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,10 @@
 [[redirects]]
+from = "*"
+to = "https://docs.tetrate.io/istio-distro"
+status = 301
+force = true
+
+[[redirects]]
 from = "https://getistio.io"
 to = "https://istio.tetratelabs.io"
 status = 301


### PR DESCRIPTION
We are ready to retire https://istio.tetratelabs.io/

This PR will set up redirect from https://istio.tetratelabs.io/ to https://docs.tetrate.io/istio-distro